### PR TITLE
Transfer history to about page

### DIFF
--- a/LacamasFair/Controllers/HomeController.cs
+++ b/LacamasFair/Controllers/HomeController.cs
@@ -23,6 +23,11 @@ namespace LacamasFair.Controllers
             return View();
         }
 
+        public IActionResult AboutPage() 
+        {
+            return View();
+        }
+
         public IActionResult Privacy()
         {
             return View();

--- a/LacamasFair/LacamasFair.csproj
+++ b/LacamasFair/LacamasFair.csproj
@@ -12,6 +12,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="3.1.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/LacamasFair/Views/Home/AboutPage.cshtml
+++ b/LacamasFair/Views/Home/AboutPage.cshtml
@@ -1,0 +1,35 @@
+﻿
+@{
+    ViewData["Title"] = "About Lacamas Fair";
+}
+
+<div class="text-center">
+    <h1>The History of The Lacamas Community Fair</h1>
+</div>
+
+<div class="text-center">
+    <img src="https://via.placeholder.com/150" />
+    <br />
+    <h4>Been in operation since 1929</h4>
+    <br />
+    <p>
+        In the fall of 1929, at a meeting of the Lacamas Community Club,
+        a few members brought samples of fruit and vegetables, which they arranged on a long table.
+        Those were lean years and everyone depended upon the produce from their
+        gardens to supplement the small incomes of the depression days.
+        That was the beginning of the Lacamas Community Fair, which, with the exceptions of the war years, has been an annual event ever since.
+    </p>
+    <br />
+    <p>
+        The Fair was established as a regular part of our community service program
+        providing a time and place for a community get-together, a day of recreation, sports, good eats, and friendly competition.
+        Throughout the years, the fair has served to perpetuate the friendship, old and new, formed in the community.
+    </p>
+    <br />
+    <p>
+        No admission has ever been charged. In fact, it has been said that you don't spend a dime at the Lacamas Community Fair except to eat.
+        The expense of the fair has been defrayed by local activities and support of local businesses, merchants and individuals.
+        We are especially grateful to these people and hope that they might feel compensated by goodwill and patronage of the residents of our community.
+    </p>
+</div>
+

--- a/LacamasFair/Views/Home/Index.cshtml
+++ b/LacamasFair/Views/Home/Index.cshtml
@@ -11,44 +11,10 @@
     <img src="https://via.placeholder.com/150" />
 
     <p>This site is currently under construction</p>
-
     <br />
-    @* The below content is pulled from the about page, probably good for a landing page *@
-    <h2>The History of The Lacamas Community Fair</h2>
-
-    <br />
-
-    <h4>The Lacamas Community Fair</h4>
-    <h4>has been in operation since 1929</h4>
-
-    <br />
-
-    <p>
-        In the fall of 1929, at a meeting of the Lacamas Community Club,
-        a few members brought samples of fruit and vegetables, which they arranged on a long table.
-        Those were lean years and everyone depended upon the produce from their
-        gardens to supplement the small incomes of the depression days.
-        That was the beginning of the Lacamas Community Fair, which, with the exceptions of the war years, has been an annual event ever since.
-    </p>
-
-    <br />
-
-    <p>
-        The Fair was established as a regular part of our community service program
-        providing a time and place for a community get-together, a day of recreation, sports, good eats, and friendly competition.
-        Throughout the years, the fair has served to perpetuate the friendship, old and new, formed in the community.
-    </p>
-
-    <br />
-    <p>
-        No admission has ever been charged. In fact, it has been said that you don't spend a dime at the Lacamas Community Fair except to eat.
-        The expense of the fair has been defrayed by local activities and support of local businesses, merchants and individuals.
-        We are especially grateful to these people and hope that they might feel compensated by goodwill and patronage of the residents of our community.
-    </p>
-
-
     @* This should contain a main contact email or redicrect to contacts *@
-    <h4>Should contain main contact email</h4>
-
+    <h5>For more information, please send an e-mail to:</h5>
+    <a href="mailto:LacamasFair@gmail.com">LacamasFair@gmail.com</a>
+    <br /><br />
     <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
 </div>

--- a/LacamasFair/Views/Shared/_Layout.cshtml
+++ b/LacamasFair/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - LacamasFair</title>
+    <title>@ViewData["Title"] - Lacamas Fair</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" />
 </head>
@@ -21,6 +21,9 @@
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="AboutPage">About Us</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>


### PR DESCRIPTION
Closes #30 
I only transferred the history part for now, since it's a separate issue. I will finish the rest of the about me page on the next issue. I also added their contact email in the home page in replacement for the fair history being transferred to the about page.