### PR TITLE
Removed extra white space and edited the iframe tag

### DIFF
--- a/LacamasFair/Views/Home/Index.cshtml
+++ b/LacamasFair/Views/Home/Index.cshtml
@@ -15,13 +15,11 @@
 
     @* Google map for address *@
     <div id="googleMap">
-        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2722.8002270182265!2d-122.4440976843916!3d46.96561497914742!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x549119fee82989df%3A0x44daaa2845b66644!2sLacamas%20Community%20Club!5e0!3m2!1sen!2sus!4v1581032481085!5m2!1sen!2sus" width="400" height="300" frameborder="0" style="border:0;" allowfullscreen=""></iframe>
+        <iframe 
+            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2722.8002270182265!2d-122.4440976843916!3d46.96561497914742!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x549119fee82989df%3A0x44daaa2845b66644!2sLacamas%20Community%20Club!5e0!3m2!1sen!2sus!4v1581032481085!5m2!1sen!2sus" 
+            width="400" height="300" frameborder="0" style="border:0;" allowfullscreen="">
+        </iframe>
     </div>
-
-
-
-
-
 
     @* This should contain a main contact email or redicrect to contacts *@
     <h5>For more information, please send an e-mail to:</h5>


### PR DESCRIPTION
I removed the extra white spaces that was below the embedded google map code as Joe suggested. I also edited the iframe tag to first as much without having to scroll all the way to the right, so most of the tag and it's attributes are visible. Couldn't do much with the source attribute, because it's such a long URL.