### PR TITLE
Adjusted the positioning of the Privacy navigation link

### DIFF
--- a/LacamasFair/Views/Shared/_Layout.cshtml
+++ b/LacamasFair/Views/Shared/_Layout.cshtml
@@ -29,10 +29,11 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="FacilityRental"> Facility Rental</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Department" asp-action="DepartmentHome">Department Home</a>
+                        </li>
+                        @* Keep the privacy nav-link at the bottom, so it appears at the end when all of the other navigation links are implemented *@
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>
                 </div>


### PR DESCRIPTION
Closes #45 
I placed the Privacy nav-link at the end of all the current nav-links. I also put a comment in the code on where to place the new navigation links, so when we are putting ones, the privacy link stays at the end. I just placed it at the end, because I think it will be the least visited section of the website and by having it at the very end, to me, it would look a bit more organized.