### PR TITLE
Fix invalid job name

### DIFF
--- a/.github/workflows/deployToAzure.yml
+++ b/.github/workflows/deployToAzure.yml
@@ -5,7 +5,7 @@ on:
     types: [published] # https://help.github.com/en/actions/reference/events-that-trigger-workflows#release-event-release
 
 jobs:
-  build and deploy:
+  build-and-deploy:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The job name does not allow spaces so those had to be replaced with dashes or underscores