### PR TITLE
Fixed the missing mobile hamburger menu to open up the navigation

### DIFF
--- a/LacamasFair/Views/Shared/_Layout.cshtml
+++ b/LacamasFair/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <partial name="_Head.cshtml" />
 <body class="background text-white">
     <header>
-        <nav class="background-dark navbar navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
+        <nav class="navbar navbar-light navbar-expand-sm navbar-toggleable-sm border-bottom box-shadow mb-3">
                 <div class="container">
                     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                             aria-expanded="false" aria-label="Toggle navigation">
@@ -34,7 +34,7 @@
                         </ul>
                     </div>
                 </div>
-            </nav>
+        </nav>
 </header>
     <div class="container">
         <main role="main" class="pb-3">


### PR DESCRIPTION
Closes #88 

I fixed missing hamburger mobile menu. It turns out, it wasn't missing at all. The color was just originally dark and when we changed the website theme, it looked missing.